### PR TITLE
Change Use Cached Data and Recommended Regions defaults to false

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "use_cached_data" {
   type        = bool
-  default     = true
+  default     = false
   description = <<DESCRIPTION
 If true, the module will use cached data from the data directory. If false, the module will use live data from the Azure API.
 
@@ -14,7 +14,7 @@ DESCRIPTION
 
 variable "recommended_regions_only" {
   type        = bool
-  default     = true
+  default     = false
   description = <<DESCRIPTION
 If true, the module will only return regions that are have the category set to `Recommended` by the locations API.
 DESCRIPTION


### PR DESCRIPTION
When attempting to change use_cached_data from the default (true) to false users will encounter an error if the cached list's length is different then the non-cached list.

![image](https://github.com/Azure/terraform-azurerm-regions/assets/3155241/f9a3d0af-fcc2-4433-88c7-71bbceb822b4)

This essentially breaks the ability of the module to pull the latest data from azure which I would argue should be the default behavior. Caching, if we can get it to work, should be an optional behavior to optimize performance. However, I'm not sure if this will be possible to do in an effective way since in Terraform, you can't have a conditional expression where the return types have different lengths because Terraform expects consistent types in both branches of the conditional. The error occurs because Terraform treats the list or tuple length as part of its type, and it requires the types to match between the true and false branches of the conditional.

To work around this, you can ensure that both branches return values of the same length. One common approach is to pad the shorter list with null values to match the length of the longer list, as shown in the examples provided earlier. This way, you maintain a consistent return type across both branches of the conditional, which satisfies Terraform's type checking requirements however, it would introduce unacceptable lack of data integrity that the consumers of the module would expect.

I recommend disabling the caching feature by default until a better solution can be worked out. 

With regard to recommended regions set to false. I think the most important utility this module provides is a definitive list of Azure regions. If it is implicitly filtering based on an arbitrary / qualitative attribute like "Recommended" then it is not meeting its primary objective. Recommend defaulting to false. Users can then use the metadata to filter based on Recommended if they so choose using a for-expression.